### PR TITLE
Remove API key example and reformat URL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,4 +18,4 @@ Imports:
 Encoding: UTF-8
 LazyData: true
 ByteCompile: true
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0

--- a/R/flw_set_api_key.R
+++ b/R/flw_set_api_key.R
@@ -7,4 +7,6 @@ flw_set_api_key<-function(api_key){
   cat(paste0("follow_the_money_key=",api_key, "\n"),
       file=file.path(normalizePath("~/"), ".Renviron"),
       append=TRUE)
+  if(Sys.setenv(follow_the_money_key = api_key))
+    message("Successfully set API key. Please restart the R session to reload the environment file.\n")
 }

--- a/R/flw_set_api_key.R
+++ b/R/flw_set_api_key.R
@@ -7,6 +7,4 @@ flw_set_api_key<-function(api_key){
   cat(paste0("follow_the_money_key=",api_key, "\n"),
       file=file.path(normalizePath("~/"), ".Renviron"),
       append=TRUE)
-  if(Sys.setenv(follow_the_money_key = api_key))
-    message("Successfully set API key. Please restart the R session to reload the environment file.\n")
 }

--- a/man/flw_get_contributions.Rd
+++ b/man/flw_get_contributions.Rd
@@ -5,9 +5,12 @@
 \title{Get contribution data from Follow The Money}
 \usage{
 flw_get_contributions(state = NULL, year = NULL, entity = NULL,
-  api_key = NULL)
+  api_key = NULL, tidy = FALSE)
+}
+\arguments{
+\item{api_key}{}
 }
 \description{
 This package utilizes the Follow The Money API and returns a tidy data frame
-of state level political contributions
+of political contributions.
 }


### PR DESCRIPTION
I've taken out the example API key.

For some reason, I couldn't get the URL to work either, so I tried reformatting it. This way works for me.